### PR TITLE
add Linux Mint MATE support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
 panel-applet-generator
 -----------------------
-Makes all the basic boilerplate for applets that are compatible with both 2.x and 3.x Gnome panels.
+Makes all the basic boilerplate for applets that are compatible with both 2.x
+and 3.x Gnome and MATE panels.
 
 Usage: panel-applet-generator.py [options]
 

--- a/panel-applet-generator.py
+++ b/panel-applet-generator.py
@@ -33,9 +33,11 @@ scriptRoot = "/usr/lib/gnome-applets"
 templates = [
 		("applet.py", "%sApplet.py" % name),
 		("bonobo-server.template", "%s.server" % name),
+		("mate-server.template", "%s-mate.server" % name),
 		("dbus-service.template", "org.gnome.panel.applet.%s.service" % name),
 		("factory2.py", "%s-factory2.py" % name),
 		("factory3.py", "%s-factory3.py" % name),
+		("factoryMate.py", "%s-factoryMate.py" % name),
 		("panel-applet.template", "org.gnome.applets.%s.panel-applet" % name),
 		]
 

--- a/templates/bonobo-server.template
+++ b/templates/bonobo-server.template
@@ -13,7 +13,7 @@
   </oaf_server>
 	<oaf_server iid="OAFIID:${name}"
 				type="factory" 
-				location='OAFIID:${name}_Factory'>
+				location="OAFIID:${name}_Factory">
 
 			<oaf_attribute name="repo_ids" type="stringv">
 					<item value="IDL:GNOME/Vertigo/PanelAppletShell:1.0"/>

--- a/templates/debian/control
+++ b/templates/debian/control
@@ -8,6 +8,11 @@ Standards-Version: 3.9.2
 
 Package: ${lowerName}
 Architecture: any
-Depends: $${shlibs:Depends}, $${misc:Depends}, gir1.2-gtk-3.0 | python-gtk2, gir1.2-panelapplet-4.0 | python-gnomeapplet, gnome-icon-theme, gnome-panel
+Depends: $${shlibs:Depends},
+         $${misc:Depends},
+         gir1.2-gtk-3.0 | python-gtk2,
+         gir1.2-panelapplet-4.0 | python-gnomeapplet | libmatepanelapplet,
+         gnome-icon-theme | mate-icon-theme,
+         gnome-panel | mate-panel
 Description: <insert up to 60 chars description>
  <insert long description, indented with spaces>

--- a/templates/debian/install
+++ b/templates/debian/install
@@ -4,3 +4,5 @@ ${name}-factory2.py usr/lib/gnome-applets
 ${name}-factory3.py usr/lib/gnome-applets
 ${name}Applet.py usr/lib/gnome-applets
 ${name}.server usr/lib/bonobo/servers 
+${name}-factoryMate.py usr/lib/mate-applets
+${name}-mate.server usr/lib/matecomponent/servers

--- a/templates/debian/links
+++ b/templates/debian/links
@@ -1,0 +1,1 @@
+${scriptRoot}/${name}Applet.py usr/lib/mate-applets/${name}Applet.py

--- a/templates/factoryMate.py
+++ b/templates/factoryMate.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+
+import sys
+import gtk
+import pygtk
+pygtk.require('2.0')
+import mateapplet
+from ${name}Applet import applet_factory
+
+if __name__ == '__main__':       # testing for execution
+    print('Starting factory')
+
+    if len(sys.argv) > 1 and sys.argv[1] == '-d': # debugging
+        mainWindow = gtk.Window()
+        mainWindow.set_title('Applet window')
+        mainWindow.connect('destroy', gtk.main_quit)
+        applet = mateapplet.Applet()
+        applet_factory(applet, None)
+        applet.reparent(mainWindow)
+        mainWindow.show_all()
+        gtk.main()
+        sys.exit()
+    else:
+        mateapplet.matecomponent_factory('OAFIID:MATE_${name}_Factory',
+                        mateapplet.Applet.__gtype__,
+                        'MATE_${name}',
+                        '0.1',
+                        applet_factory)

--- a/templates/mate-server.template
+++ b/templates/mate-server.template
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+
+<oaf_info>
+	<oaf_server iid="OAFIID:MATE_${name}_Factory"
+		type="exe"
+		location="/usr/lib/mate-applets/${name}-factoryMate.py">
+        <oaf_attribute name="repo_ids" type="stringv">
+                <item value="IDL:MateComponent/GenericFactory:1.0"/>
+                <item value="IDL:MateComponent/Unknown:1.0"/>
+        </oaf_attribute>
+        <oaf_attribute name="name" type="string" value="${name}"/>
+        <oaf_attribute name="description" type="string" value="${description}"/>
+  </oaf_server>
+	<oaf_server iid="OAFIID:MATE_${name}"
+				type="factory"
+				location="OAFIID:MATE_${name}_Factory">
+
+			<oaf_attribute name="repo_ids" type="stringv">
+					<item value="IDL:MATE/Vertigo/MatePanelAppletShell:1.0"/>
+					<item value="IDL:MateComponent/Control:1.0"/>
+					<item value="IDL:MateComponent/Unknown:1.0"/>
+			</oaf_attribute>
+			<oaf_attribute name="name" type="string" value="${name}"/>
+			<oaf_attribute name="description" type="string" value="${description}"/>
+			<oaf_attribute name="panel:category" type="string" value="${category}"/>
+			<oaf_attribute name="panel:icon" type="string" value="${icon}"/>
+	</oaf_server>
+</oaf_info>


### PR DESCRIPTION
Attached are two patches, one a minor bug fix, and the other adds Linux Mint MATE
support to your generator. 
